### PR TITLE
On some systems, glob() will return false if no files were found.

### DIFF
--- a/src/TccAbstractModule/Module/AbstractModuleNoTraits.php
+++ b/src/TccAbstractModule/Module/AbstractModuleNoTraits.php
@@ -75,6 +75,10 @@ abstract class AbstractModuleNoTraits implements
             GLOB_BRACE
         );
 
+        // glob() returns false on error. On some systems, glob() will return false (instead of an empty array) if no
+        // files are found. Treat both in the same way - no config will be loaded.
+        $configFiles = $configFiles ?: array();
+
         $config = array();
         foreach ($configFiles as $configFile) {
             $config = ArrayUtils::merge($config, include $configFile);
@@ -94,6 +98,10 @@ abstract class AbstractModuleNoTraits implements
             $this->getDir() . '/' . $this->relativeModuleDir . 'config/service/controller.config{,.*}.php',
             GLOB_BRACE
         );
+
+        // glob() returns false on error. On some systems, glob() will return false (instead of an empty array) if no
+        // files are found. Treat both in the same way - no config will be loaded.
+        $configFiles = $configFiles ?: array();
 
         $config = array();
         foreach ($configFiles as $configFile) {
@@ -115,6 +123,10 @@ abstract class AbstractModuleNoTraits implements
             GLOB_BRACE
         );
 
+        // glob() returns false on error. On some systems, glob() will return false (instead of an empty array) if no
+        // files are found. Treat both in the same way - no config will be loaded.
+        $configFiles = $configFiles ?: array();
+
         $config = array();
         foreach ($configFiles as $configFile) {
             $config = ArrayUtils::merge($config, include $configFile);
@@ -134,6 +146,10 @@ abstract class AbstractModuleNoTraits implements
             $this->getDir() . '/' . $this->relativeModuleDir . 'config/service/viewhelper.config{,.*}.php',
             GLOB_BRACE
         );
+
+        // glob() returns false on error. On some systems, glob() will return false (instead of an empty array) if no
+        // files are found. Treat both in the same way - no config will be loaded.
+        $configFiles = $configFiles ?: array();
 
         $config = array();
         foreach ($configFiles as $configFile) {

--- a/src/TccAbstractModule/ModuleManager/Feature/ConfigProviderTrait.php
+++ b/src/TccAbstractModule/ModuleManager/Feature/ConfigProviderTrait.php
@@ -21,6 +21,10 @@ trait ConfigProviderTrait
             GLOB_BRACE
         );
 
+        // glob() returns false on error. On some systems, glob() will return false (instead of an empty array) if no
+        // files are found. Treat both in the same way - no config will be loaded.
+        $configFiles = $configFiles ?: array();
+
         $config = array();
         foreach ($configFiles as $configFile) {
             $config = ArrayUtils::merge($config, include $configFile);

--- a/src/TccAbstractModule/ModuleManager/Feature/ControllerConfigProviderTrait.php
+++ b/src/TccAbstractModule/ModuleManager/Feature/ControllerConfigProviderTrait.php
@@ -22,6 +22,10 @@ trait ControllerConfigProviderTrait
             GLOB_BRACE
         );
 
+        // glob() returns false on error. On some systems, glob() will return false (instead of an empty array) if no
+        // files are found. Treat both in the same way - no config will be loaded.
+        $configFiles = $configFiles ?: array();
+
         $config = array();
         foreach ($configFiles as $configFile) {
             $config = ArrayUtils::merge($config, include $configFile);

--- a/src/TccAbstractModule/ModuleManager/Feature/ServiceConfigProviderTrait.php
+++ b/src/TccAbstractModule/ModuleManager/Feature/ServiceConfigProviderTrait.php
@@ -22,6 +22,10 @@ trait ServiceConfigProviderTrait
             GLOB_BRACE
         );
 
+        // glob() returns false on error. On some systems, glob() will return false (instead of an empty array) if no
+        // files are found. Treat both in the same way - no config will be loaded.
+        $configFiles = $configFiles ?: array();
+
         $config = array();
         foreach ($configFiles as $configFile) {
             $config = ArrayUtils::merge($config, include $configFile);

--- a/src/TccAbstractModule/ModuleManager/Feature/ViewHelperConfigProviderTrait.php
+++ b/src/TccAbstractModule/ModuleManager/Feature/ViewHelperConfigProviderTrait.php
@@ -22,6 +22,10 @@ trait ViewHelperConfigProviderTrait
             GLOB_BRACE
         );
 
+        // glob() returns false on error. On some systems, glob() will return false (instead of an empty array) if no
+        // files are found. Treat both in the same way - no config will be loaded.
+        $configFiles = $configFiles ?: array();
+
         $config = array();
         foreach ($configFiles as $configFile) {
             $config = ArrayUtils::merge($config, include $configFile);


### PR DESCRIPTION
glob() always returns false on error. This makes it impossible to determine an error case and also previously caused a PHP error as no false handling was in place. This commit adds handling of false values (by skipping config loading for that aspect).
