### PR TITLE
Older versions of PHP do not support object dereferencing (instantiating...

### DIFF
--- a/src/TccAbstractModule/Module/AbstractModuleNoTraits.php
+++ b/src/TccAbstractModule/Module/AbstractModuleNoTraits.php
@@ -166,7 +166,8 @@ abstract class AbstractModuleNoTraits implements
      */
     protected function getDir()
     {
-        return dirname((new \ReflectionClass(get_class($this)))->getFileName());
+        $reflectionClass = new \ReflectionClass(get_class($this));
+        return dirname($reflectionClass->getFileName());
     }
 
     /**
@@ -177,6 +178,7 @@ abstract class AbstractModuleNoTraits implements
      */
     protected function getNamespace()
     {
-        return (new \ReflectionClass(get_class($this)))->getNamespaceName();
+        $reflectionClass = new \ReflectionClass(get_class($this));
+        return dirname($reflectionClass->getNamespaceName());
     }
 }


### PR DESCRIPTION
... an object in parentheses and immediately calling a function on that object).
